### PR TITLE
Gfen patch 1

### DIFF
--- a/AnimationPath/Assets/AnimationPath/Editor/AnimationWindowReflect.cs
+++ b/AnimationPath/Assets/AnimationPath/Editor/AnimationWindowReflect.cs
@@ -17,12 +17,14 @@ public class AnimationWindowReflect
     private object m_AnimEditor;
     private object m_AnimationWindowState;
     private object m_AnimationWindowSelection;
+    private PropertyInfo m_playingInfo;
     private PropertyInfo m_recordingInfo;
     private PropertyInfo m_currentTimeInfo;
     private PropertyInfo m_activeRootGameObjectInfo;
     private PropertyInfo m_activeAnimationClipInfo;
     private FieldInfo m_onClipSelectionChangedInfo;
     private Func<float> m_CurrentTimeGetFunc;
+    private MethodInfo m_ResampleAnimationMethod;
 
     private Assembly assembly
     {
@@ -152,6 +154,27 @@ public class AnimationWindowReflect
         }
     }
 
+    private PropertyInfo playingInfo
+    {
+        get
+        {
+            if (m_playingInfo == null)
+            {
+                m_playingInfo = animationWindowStateType.GetProperty("playing", BindingFlags.Instance | BindingFlags.Public);
+            }
+            return m_playingInfo;
+        }
+    }
+
+    /// <summary>
+    /// 是否正在播放动画
+    /// </summary>
+    public bool playing
+    {
+        get { return (bool) playingInfo.GetValue(animationWindowState, null); }
+        set { playingInfo.SetValue(animationWindowState, value, null); }
+    }
+    
     private PropertyInfo recordingInfo
     {
         get
@@ -270,5 +293,14 @@ public class AnimationWindowReflect
         get { return (Action) onClipSelectionChangedInfo.GetValue(animationWindowState); }
         set { onClipSelectionChangedInfo.SetValue(animationWindowState, value);}
 #endif
+    }
+    
+    public void ResampleAnimation()
+    {
+        if (m_ResampleAnimationMethod == null)
+        {
+            m_ResampleAnimationMethod = animationWindowStateType.GetMethod("ResampleAnimation", BindingFlags.Instance | BindingFlags.Public);
+        }
+        m_ResampleAnimationMethod.Invoke(animationWindowState, null);
     }
 }

--- a/AnimationPath/Assets/AnimationPath/Editor/AnimationWindowUtil.cs
+++ b/AnimationPath/Assets/AnimationPath/Editor/AnimationWindowUtil.cs
@@ -135,8 +135,10 @@ public static class AnimationWindowUtil
             return;
         }
 
-        animationWindowReflect.recording = true;
         animationWindowReflect.currentTime = time;
+        animationWindowReflect.recording = true;
+        animationWindowReflect.playing = false;
+        animationWindowReflect.ResampleAnimation();
         animationWindowReflect.firstAnimationWindow.Repaint();
     }
 


### PR DESCRIPTION
我发现场景中点击的关键帧和Animation Window中的相同时，不会触发ResampleAnimation。这会导致第一次显示路径时，如果选中的点和Animation Window中当前激活的Clip的当前帧相同时，不会触发选中效果，即动画物体不会移动至该点。